### PR TITLE
fix: ghworkflow tagging

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@bhalle @springframeworkguru

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.12"]
     permissions:
       packages: write
       contents: write
@@ -40,6 +40,13 @@ jobs:
           username: ${{ vars.QUAY_USER }}
           password: ${{ secrets.QUAY_KEY }}
 
+      - name: Bump version and push tag
+        id: bump
+        uses: anothrNick/github-tag-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: false
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
@@ -63,13 +70,6 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Bump version and push tag
-        id: bump
-        uses: anothrNick/github-tag-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WITH_V: false
 
       - name: Send custom JSON data to Slack workflow
         id: slack


### PR DESCRIPTION
revert github workflow steps ordering ... as bump needs to happen prior to container image tagging

added codeowners file to aid in pr configuration rules